### PR TITLE
Fix file-picker in distributable

### DIFF
--- a/desktop-app/build.gradle.kts
+++ b/desktop-app/build.gradle.kts
@@ -54,6 +54,9 @@ compose.desktop {
         mainClass = "info.marozzo.hematoma.MainKt"
 
         nativeDistributions {
+
+            modules("jdk.unsupported")
+
             targetFormats(TargetFormat.Deb, TargetFormat.Exe)
             packageName = rootProject.name
             description = "Tournament planner for HEMA tournaments of the club 'Fior della Spada'"


### PR DESCRIPTION
Add the `jdk.unsupported` module to native distribution, which is required by the [mp file-picker](https://github.com/Wavesonics/compose-multiplatform-file-picker/issues/87).