### PR TITLE
Enable kotlin compilers extra warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,8 @@ allprojects {
 
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
-            allWarningsAsErrors = true
+            extraWarnings.set(true)
+            allWarningsAsErrors.set(true)
             jvmTarget.set(javaVersionJvm)
         }
     }

--- a/desktop-app/src/main/kotlin/info/marozzo/hematoma/components/Scoring.kt
+++ b/desktop-app/src/main/kotlin/info/marozzo/hematoma/components/Scoring.kt
@@ -346,7 +346,7 @@ private data class CompetitorResult(
 
 
 val statsCollector = Collector.nonSuspendOf<Atomic<Result>, Result, Result>(
-    supply = { Atomic(Result.empty) },
+    supply = { Atomic(EmptyResult) },
     accumulate = { acc, value -> acc.update { it + value } },
     finish = { it.get() },
     characteristics = Characteristics.CONCURRENT_UNORDERED

--- a/desktop-app/src/main/kotlin/info/marozzo/hematoma/contract/EventState.kt
+++ b/desktop-app/src/main/kotlin/info/marozzo/hematoma/contract/EventState.kt
@@ -33,7 +33,7 @@ data class EventState(
     ),
     val screen: Screen = Screen.Configuration
 ) {
-    companion object
+    internal companion object
 }
 
 enum class Screen {

--- a/domain/src/main/kotlin/info/marozzo/hematoma/domain/scoring/Result.kt
+++ b/domain/src/main/kotlin/info/marozzo/hematoma/domain/scoring/Result.kt
@@ -34,7 +34,7 @@ data class Result(
 ) {
     val cut = scored / conceded
 
-    companion object {
+    internal companion object {
         val empty = Result(
             matches = Matches.none,
             wins = Matches.none,
@@ -54,3 +54,5 @@ data class Result(
         doubleHits + other.doubleHits
     )
 }
+
+val EmptyResult = Result.empty

--- a/domain/src/main/kotlin/info/marozzo/hematoma/domain/scoring/ScoringSettings.kt
+++ b/domain/src/main/kotlin/info/marozzo/hematoma/domain/scoring/ScoringSettings.kt
@@ -34,7 +34,7 @@ data class FiorDellaSpadaScoring(
     val winningThreshold: Score = DEFAULT_WINNING_THRESHOLD
 ) : ScoringSettings {
 
-    companion object {
+    internal companion object {
         private const val MAX_AWARDED = 3.0
         private val DEFAULT_WINNING_THRESHOLD = Score(7)
     }


### PR DESCRIPTION
switch companion objects of @optics annotated classes to internal to avoid warnings in @optics generated code